### PR TITLE
Feature/probes

### DIFF
--- a/.circleci/images/web/Dockerfile
+++ b/.circleci/images/web/Dockerfile
@@ -13,12 +13,9 @@ RUN apt-get install python3-pip -y
 #Install RabbitMQ
 RUN apt-get install rabbitmq-server
 
+#Copy requirements.txt into container
+COPY requirements.txt .
+
 #Install requirements
 RUN pip3 install -r requirements.txt
-
-#Run RabbitMQ
-RUN systemctl enable rabbitmq-server
-
-#Run a Celery worker
-RUN celery -A web worker
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ asgiref==3.3.1
 beautifulsoup4==4.9.3
 certifi==2020.12.5
 chardet==4.0.0
-Django==3.1.7
+Django==3.1.8
 django-environ==0.4.5
 django-extensions==3.1.1
 django-livereload-server==0.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ asgiref==3.3.1
 beautifulsoup4==4.9.3
 certifi==2020.12.5
 chardet==4.0.0
-Django==3.1.8
+Django==3.1.7
 django-environ==0.4.5
 django-extensions==3.1.1
 django-livereload-server==0.3.2
@@ -11,6 +11,7 @@ django-tailwind==2.0.0
 django-widget-tweaks==1.4.8
 idna==2.10
 Pillow==8.1.2
+psycopg2==2.8.6
 pytz==2021.1
 requests==2.25.1
 six==1.15.0
@@ -20,4 +21,3 @@ stripe==2.56.0
 tornado==6.1
 urllib3==1.26.4
 celery==5.0.5
-


### PR DESCRIPTION
This removes celery and rabbitmq commands from Dockerfile as they are added instead in the .circleci/config.yml file in the web repo; it also adds psycopg2 in requirements.txt; psycopg2 is the most popular PostgreSQL database adapter for Python. 